### PR TITLE
remove/relocate intrusive CSS

### DIFF
--- a/css/kindling.css
+++ b/css/kindling.css
@@ -14,10 +14,6 @@
 	* {
 		margin: 0;
 		padding: 0;
-		position: relative;
-		-webkit-box-sizing:border-box;
-		-moz-box-sizing:border-box;
-		box-sizing:border-box;
 	}
 	body {
 		font: 300 125%/150% sans-serif;
@@ -31,6 +27,11 @@
     Grid
 
 */
+	.col, .row {
+		-webkit-box-sizing:border-box;
+		-moz-box-sizing:border-box;
+		box-sizing:border-box;
+	}
 
 	.row:after,.col:after {
 		content:"";


### PR DESCRIPTION
box-sizing on every element (*) is very intrusive, and can have some bad side-effects (http://caniuse.com/#feat=css3-boxsizing under the tab issues)

Same for position relative, I feel this is very intrusive as well, makes positioning elements with position: absolute a pain.
