### PR TITLE
make class subset match more accurate

### DIFF
--- a/css/kindling.css
+++ b/css/kindling.css
@@ -6,7 +6,7 @@
 	max-width: 1400px;
 	margin: auto;
 }
-[class*=col-] {
+[class^=col-] {
 	-ms-flex: 1;
 	    flex: 1;
 	padding: 1rem;
@@ -41,5 +41,5 @@
 .offset-12 { margin-left: 100%; }
 @media only screen and (max-width: 850px) {
 	.row { -ms-flex-direction: column; flex-direction: column; }
-	[class*=offset-] { margin-left: 0; }
+	[class^=offset-] { margin-left: 0; }
 }


### PR DESCRIPTION
Currently, the classes will match `.foo-col-1`, rather than just `.col-1`, which I believe is not intended. This changes it to use prefix matching instead.